### PR TITLE
Fix variance formula

### DIFF
--- a/src/main/scala/org/scalaml/stats/Stats.scala
+++ b/src/main/scala/org/scalaml/stats/Stats.scala
@@ -59,8 +59,12 @@ class Stats[T <% Double](values: DVector[T]) {
 		/**
 		 * Computation of variance for the array values
 		 */
-	lazy val variance = (_stats.sumSqr - mean*mean*values.size)/(values.size-1)
-		 
+	lazy val variance: Double = {
+		val n = values.size
+		val E2 = _stats.sumSqr / n
+		(E2 - math.pow(mean, 2)) * n / (n - 1)
+	}
+	
 		/**
 		 * Computation of standard deviation for the array values
 		 */


### PR DESCRIPTION
Variance calculation and its dependent values seem to be off.
Ex. 
Old:
scala> val oldS = new org.scalaml.stats.Stats((0 to 10).toArray)
oldS: org.scalaml.stats.Stats[Int] = org.scalaml.stats.Stats@2c8038d8

scala> oldS.variance
res5: Double = 38.27272727272727

scala> oldS.stdDev
res6: Double = 6.186495556672394

New:
scala> val s = Stats(0 to 10)
s: Stats[Int] = Stats(Range(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))

scala> s.variance
res3: Double = 11.0

scala> s.stdDev
res4: Double = 3.3166247903554

update: Nevermind. 
